### PR TITLE
Added instruction explaining use of temporary tool-chain creation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ The Whitewater internal IBM server is at [https://github.ibm.com](https://github
 
 [![Deploy To IBM Cloud](https://cloud.ibm.com/devops/graphics/create_toolchain_button.png)](https://dev.console.test.cloud.ibm.com/devops/setup/deploy?repository=https%3A//github.com/maire-kehoe/whitewater-ref-toolchain&env_id=ibm:yp:us-south) dev
 
-Instructions 
+Instructions
+
 These steps can be used to prevent authorization errors when using tool-chain links that assume authorization has already been given. 
 Clicking on the buttons will kick off the creation of a (fake) tool chain. This is only used to get you to the step of authorizing access (of the Whitewater server) to your repository - which is needed to create your own tool chain later. After authorizing you will cancel this tool-chain creation and can continue with the creation of your own toolchain.
 1. Click on the button to use either the IBM production or the IBM test cloud (https://test.cloud.ibm.com) depending where you want to deploy to

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ The Whitewater internal IBM server is at [https://github.ibm.com](https://github
 
 [![Deploy To IBM Cloud](https://cloud.ibm.com/devops/graphics/create_toolchain_button.png)](https://dev.console.test.cloud.ibm.com/devops/setup/deploy?repository=https%3A//github.com/maire-kehoe/whitewater-ref-toolchain&env_id=ibm:yp:us-south) dev
 
+Instructions 
+These steps can be used to prevent authorization errors when using tool-chain links that assume authorization has already been given. 
+Clicking on the buttons will kick off the creation of a (fake) tool chain. This is only used to get you to the step of authorizing access (of the Whitewater server) to your repository - which is needed to create your own tool chain later. After authorizing you will cancel this tool-chain creation and can continue with the creation of your own toolchain.
+1. Click on the button to use either the IBM production or the IBM test cloud (https://test.cloud.ibm.com) depending where you want to deploy to
+2. You will presented with the "create tool chain" screen. You can ignore all and click the "authorize button" and follow the repo authorization.
+3. After the repo is authorized, click `Cancel`to cancel the tool chain creation (it's pointing to a fake/placeholder repo anyway).
+You can now continue with the creation of your own toolchain.
+
+Alternatively you can add your repo access token to the URL that creates "your" tool chain <your-Cloud-URL>/devops/setup/deploy/?repository=<your-repo-URL>&repository_token=<GHE_PAT>[&branch=<branch if not default branch>]
 
 Note, the Whitewater tool integration is only available in accounts associated with IBM users.  
 Non-IBM users who open the click the above button will see an error dialog like:


### PR DESCRIPTION
Just as it wasn't immediately clear to me that we use the process of a tool chain creation for authorization only
Also added that users could add PAT in URL to authorize directly 
Just in case it's useful to others